### PR TITLE
passim.service: explicitly depend on avahi-daemon

### DIFF
--- a/data/passim.service.in
+++ b/data/passim.service.in
@@ -1,8 +1,9 @@
 [Unit]
 Description=A local caching server
 Documentation=https://github.com/hughsie/passim
-After=dbus.service
+After=avahi-daemon.service
 Before=display-manager.service
+Wants=avahi-daemon.service
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Unfortunately, dbus activation of avahi is broken if avahi-daemon.service has not been enabled via systemctl before (see https://github.com/lathiat/avahi/issues/29).

If passim.service is started by dbus via org.freedesktop.Passim.service, dbus will wait 25 seconds for it to come up, causing large delays in any application trying to talk to passim via dbus.

As a workaround for the non-functional bus activation, directly depend on avahi-daemon.service in passim.service.

Fixes https://github.com/hughsie/passim/issues/15