### PR TITLE
systemd: Add [Install] section

### DIFF
--- a/data/passim.service.in
+++ b/data/passim.service.in
@@ -36,3 +36,6 @@ SystemCallErrorNumber=EPERM
 SystemCallArchitectures=native
 StateDirectory=passim passim/data
 LogsDirectory=passim
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
When passim is installed, because it's a dbus service, it's unconditionally started by systemd and not activated on demand (because systemd does not support on demand starting of dbus services).

As always starting passim if it is installed might not be desirable (e.g. on Arch Linux which doesn't do split packaging of the passim library and daemon), let's add an [Install] section so that passim can be explicitly enabled using systemctl enable/disable, with the default enablement being decided by systemd.preset.