### PR TITLE
Handle non-numeric addresses from the Avahi resolver

### DIFF
--- a/src/passim-avahi-service-resolver.c
+++ b/src/passim-avahi-service-resolver.c
@@ -113,6 +113,15 @@ passim_avahi_service_resolver_signal(GTask *task, const gchar *signal_name, GVar
 			      NULL,
 			      NULL);
 		socket_addr = g_inet_socket_address_new_from_string(host, port);
+		if (socket_addr == NULL) {
+			g_task_return_new_error(task,
+						G_IO_ERROR,
+						G_IO_ERROR_INVALID_DATA,
+						"mDNS responder returned non-numeric address '%s'",
+						host);
+			passim_avahi_service_resolver_free(task);
+			return;
+		}
 		if (g_socket_address_get_family(socket_addr) == G_SOCKET_FAMILY_IPV6) {
 			helper->address = g_strdup_printf("[%s]:%i", host, port);
 		} else {


### PR DESCRIPTION
g_inet_socket_address_new_from_string() returns NULL when the host is not a valid numeric IPv4/IPv6 literal, which a malicious or misbehaving mDNS responder on the LAN can easily supply. The unchecked result was then dereferenced by g_socket_address_get_family(), tripping a critical precondition and aborting the daemon. The Found handler now returns an error to the task instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service discovery error handling when a resolver returns an invalid, non-numeric address.
  * Reports a clear error instead of continuing with invalid connection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->