### PR TITLE
Skip unknown flag bits when building the item flags string

### DIFF
--- a/libpassim/passim-item.c
+++ b/libpassim/passim-item.c
@@ -698,11 +698,15 @@ passim_item_get_flags_as_string(PassimItem *self)
 	g_return_val_if_fail(PASSIM_IS_ITEM(self), NULL);
 
 	for (guint i = 0; i < 64; i++) {
+		const gchar *tmp;
 		if ((priv->flags & ((guint64)1 << i)) == 0)
+			continue;
+		tmp = passim_item_flag_to_string((guint64)1 << i);
+		if (tmp == NULL)
 			continue;
 		if (str->len > 0)
 			g_string_append(str, ",");
-		g_string_append(str, passim_item_flag_to_string((guint64)1 << i));
+		g_string_append(str, tmp);
 	}
 	if (str->len == 0)
 		g_string_append(str, passim_item_flag_to_string(PASSIM_ITEM_FLAG_NONE));


### PR DESCRIPTION
passim_item_flag_to_string() returns NULL for any bit it does not recognize. Since the flags value comes verbatim from a D-Bus Publish call, an unknown bit caused g_string_append() to be called with NULL, tripping a GLib precondition and aborting the daemon. Skip unknown bits instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flag display handling to prevent invalid or unavailable flag values from appearing.
  * Ensured separators are added correctly when showing multiple item flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->