### PR TITLE
Reject Publish requests that do not include a basename

### DIFF
--- a/src/passim-server.c
+++ b/src/passim-server.c
@@ -1326,8 +1326,9 @@ passim_server_method_call(GDBusConnection *connection,
 		}
 		passim_item_set_cmdline(item, cmdline);
 
-		/* sanity check this does not contain a path */
-		if (g_strstr_len(passim_item_get_basename(item), -1, "/") != NULL) {
+		/* sanity check this exists and does not contain a path */
+		if (passim_item_get_basename(item) == NULL ||
+		    g_strstr_len(passim_item_get_basename(item), -1, "/") != NULL) {
 			g_dbus_method_invocation_return_error_literal(invocation,
 								      G_DBUS_ERROR,
 								      G_DBUS_ERROR_INVALID_ARGS,


### PR DESCRIPTION
When a Publish caller omitted the filename attribute the item basename was left NULL. The path-validation check then passed NULL to g_strstr_len(), tripping a GLib precondition that aborts the daemon under fatal criticals, and the following control-character loop would have dereferenced the NULL pointer as well. Reject the request up front when the basename is missing.