### PR TITLE
Disable items that reach the share limit instead of deleting them

### DIFF
--- a/src/passim-server.c
+++ b/src/passim-server.c
@@ -868,13 +868,14 @@ passim_server_msg_send_item(PassimServer *self, SoupServerMessage *msg, PassimIt
 static void
 passim_server_check_share_limit(PassimServer *self, PassimItem *item)
 {
-	/* we've shared this enough now */
+	/* we've shared this enough now; stop serving the item but keep the
+	 * on-disk copy so that an unauthenticated peer cannot evict it from
+	 * the cache simply by exhausting the share limit */
 	if (passim_item_get_share_limit(item) > 0 &&
-	    passim_item_get_share_count(item) >= passim_item_get_share_limit(item)) {
-		g_autoptr(GError) error = NULL;
-		g_debug("deleting %s as share limit reached", passim_item_get_hash(item));
-		if (!passim_server_delete_item(self, item, &error))
-			g_warning("failed: %s", error->message);
+	    passim_item_get_share_count(item) >= passim_item_get_share_limit(item) &&
+	    !passim_item_has_flag(item, PASSIM_ITEM_FLAG_DISABLED)) {
+		g_debug("disabling %s as share limit reached", passim_item_get_hash(item));
+		passim_item_add_flag(item, PASSIM_ITEM_FLAG_DISABLED);
 	}
 }
 


### PR DESCRIPTION
Deleting a cached file once its share limit was reached let any unauthenticated LAN peer evict it from every node simply by issuing enough GET requests to exhaust the share count, forcing a WAN re-download. Mark the item disabled instead so it stops being served while the on-disk copy is retained.