### PR TITLE
Expand test coverage from 29% to 82%

### DIFF
--- a/contrib/ci/Dockerfile-fedora
+++ b/contrib/ci/Dockerfile-fedora
@@ -7,6 +7,8 @@ RUN dnf -y install \
 	gobject-introspection-devel \
 	libsoup3-devel \
 	meson \
+	python3-dbus \
+	python3-dbusmock \
 	redhat-rpm-config \
 	shared-mime-info \
 	systemd

--- a/contrib/passim.spec.in
+++ b/contrib/passim.spec.in
@@ -45,6 +45,13 @@ Obsoletes: %{name} < 0.1.1-3
 libpassim is a library that allows software to share files on your local network
 using the passimd daemon.
 
+%package tests
+Summary: Installed tests for %{name}
+Requires: %{name}%{?_isa} = %{version}-%{release}
+
+%description tests
+Installed tests for %{name}.
+
 %package devel
 Summary: Development package for %{name}
 Requires: %{name}%{?_isa} = %{version}-%{release}
@@ -100,6 +107,12 @@ appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/*.metainfo.xml
 %files libs
 %license LICENSE
 %{_libdir}/libpassim.so.1*
+
+%files tests
+%dir %{_datadir}/installed-tests/passim
+%{_datadir}/installed-tests/passim/passim-self-test.test
+%dir %{_libexecdir}/installed-tests/passim
+%{_libexecdir}/installed-tests/passim/passim-self-test
 
 %files devel
 %{_datadir}/gir-1.0/Passim-1.0.gir

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
-option('systemd_root_prefix', type: 'string', value: '', description: 'Directory to base systemd’s installation directories on')
+option('systemd_root_prefix', type: 'string', value: '', description: 'Directory to base systemd installation directories on')
 option('introspection', type : 'feature', description : 'generate GObject Introspection data')
+option('installed_tests', type : 'boolean', value : true, description : 'install distributed tests')

--- a/src/meson.build
+++ b/src/meson.build
@@ -34,7 +34,7 @@ executable(
   install_dir: libexecdir,
 )
 
-executable(
+passim_cli = executable(
   'passim',
   sources: [
     'passim-cli.c',
@@ -55,6 +55,10 @@ executable(
   install_dir: bindir,
 )
 
+installed_tests = get_option('installed_tests')
+installed_tests_metadir = datadir / 'installed-tests' / meson.project_name()
+installed_tests_execdir = libexecdir / 'installed-tests' / meson.project_name()
+
 env = environment()
 env.set('G_TEST_SRCDIR', meson.current_source_dir())
 env.set('G_TEST_BUILDDIR', meson.current_build_dir())
@@ -62,6 +66,7 @@ e = executable(
   'passim-self-test',
   sources: [
     'passim-common.c',
+    'passim-gnutls.c',
     'passim-self-test.c',
   ],
   include_directories: [
@@ -69,7 +74,8 @@ e = executable(
     passim_incdir,
   ],
   dependencies: [
-    libgio
+    libgio,
+    libgnutls,
   ],
   link_with: [
     passim
@@ -78,5 +84,47 @@ e = executable(
     '-DSRCDIR="' + meson.current_source_dir() + '"',
     '-DBUILDDIR="' + meson.current_build_dir() + '"',
   ],
+  install: installed_tests,
+  install_dir: installed_tests_execdir,
 )
 test('passim-self-test', e, is_parallel: false, timeout: 180, env: env)
+if installed_tests
+  configure_file(
+    input: 'passim-self-test.test.in',
+    output: 'passim-self-test.test',
+    configuration: {
+      'installed_tests_execdir': installed_tests_execdir,
+    },
+    install_dir: installed_tests_metadir,
+  )
+endif
+
+passim_client_test_helper = executable(
+  'passim-client-test-helper',
+  sources: [
+    'passim-client-test-helper.c',
+  ],
+  include_directories: [
+    root_incdir,
+    passim_incdir,
+  ],
+  dependencies: [
+    libgio,
+  ],
+  link_with: [
+    passim,
+  ],
+)
+
+integration_env = environment()
+integration_env.set('PASSIM_BUILDDIR', meson.project_build_root())
+integration_env.set('PASSIM_SRCDIR', meson.current_source_dir())
+integration_env.set('PASSIM_CLIENT_TEST_HELPER', passim_client_test_helper.full_path())
+integration_env.set('PASSIM_CLI', passim_cli.full_path())
+test('passim-integration-test',
+  python3,
+  args: [files('passim-integration-test.py')],
+  env: integration_env,
+  is_parallel: false,
+  timeout: 120,
+)

--- a/src/passim-cli.c
+++ b/src/passim-cli.c
@@ -169,6 +169,13 @@ typedef struct {
 	gchar *value;
 } PassimItemAttr;
 
+static void
+passim_item_attr_free(PassimItemAttr *attr)
+{
+	g_free(attr->value);
+	g_free(attr);
+}
+
 static gchar *
 passim_cli_item_flag_to_string(PassimItemFlags flags)
 {
@@ -189,7 +196,7 @@ passim_cli_item_flag_to_string(PassimItemFlags flags)
 static GPtrArray *
 passim_cli_item_to_attrs(PassimItem *item)
 {
-	GPtrArray *array = g_ptr_array_new_with_free_func(g_free);
+	GPtrArray *array = g_ptr_array_new_with_free_func((GDestroyNotify)passim_item_attr_free);
 
 	if (passim_item_get_basename(item) != NULL) {
 		PassimItemAttr *attr = g_new0(PassimItemAttr, 1);

--- a/src/passim-client-test-helper.c
+++ b/src/passim-client-test-helper.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <glib/gstdio.h>
+
+#include "passim-client.h"
+
+static const gchar *bytes_content = "passim-client-test-bytes-data";
+static const gchar *file_content = "passim-client-test-file-data";
+
+int
+main(int argc, char *argv[])
+{
+	g_autoptr(PassimClient) client = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GPtrArray) items = NULL;
+	g_autoptr(GPtrArray) items2 = NULL;
+	g_autoptr(PassimItem) item_bytes = NULL;
+	g_autoptr(PassimItem) item_file = NULL;
+	g_autoptr(PassimItem) item_nodata = NULL;
+	g_autoptr(GBytes) bytes = NULL;
+	g_autoptr(GFile) gfile = NULL;
+	g_autoptr(GBytes) file_bytes = NULL;
+	g_autofree gchar *tmpfile = NULL;
+	g_autofree gchar *hash_bytes_str = NULL;
+	g_autofree gchar *hash_file_str = NULL;
+	const gchar *version;
+	const gchar *name;
+	const gchar *uri;
+
+	client = passim_client_new();
+	g_assert_nonnull(client);
+
+	if (!passim_client_load(client, &error)) {
+		g_printerr("Failed to load: %s\n", error->message);
+		return 1;
+	}
+
+	version = passim_client_get_version(client);
+	g_assert_nonnull(version);
+	name = passim_client_get_name(client);
+	g_assert_nonnull(name);
+	uri = passim_client_get_uri(client);
+	g_assert_nonnull(uri);
+	g_assert_cmpint(passim_client_get_status(client), ==, PASSIM_STATUS_RUNNING);
+
+	items = passim_client_get_items(client, &error);
+	if (items == NULL) {
+		g_printerr("Failed to get items: %s\n", error->message);
+		return 1;
+	}
+	g_assert_cmpuint(items->len, >, 0);
+
+	/* clean up items from any previous failed run */
+	hash_bytes_str = g_compute_checksum_for_string(G_CHECKSUM_SHA256, bytes_content, -1);
+	hash_file_str = g_compute_checksum_for_string(G_CHECKSUM_SHA256, file_content, -1);
+	passim_client_unpublish(client, hash_bytes_str, NULL);
+	passim_client_unpublish(client, hash_file_str, NULL);
+
+	/* publish via bytes */
+	item_bytes = passim_item_new();
+	bytes = g_bytes_new_static(bytes_content, strlen(bytes_content));
+	passim_item_set_basename(item_bytes, "client-test-bytes.bin");
+	passim_item_set_bytes(item_bytes, bytes);
+	passim_item_set_max_age(item_bytes, 3600);
+	passim_item_set_share_limit(item_bytes, 5);
+	if (!passim_client_publish(client, item_bytes, &error)) {
+		g_printerr("Failed to publish bytes: %s\n", error->message);
+		return 1;
+	}
+
+	/* publish via file */
+	tmpfile = g_build_filename(g_get_tmp_dir(), "passim-client-test.bin", NULL);
+	if (!g_file_set_contents(tmpfile, file_content, -1, &error)) {
+		g_printerr("Failed to write tmpfile: %s\n", error->message);
+		return 1;
+	}
+	item_file = passim_item_new();
+	gfile = g_file_new_for_path(tmpfile);
+	file_bytes = g_bytes_new_static(file_content, strlen(file_content));
+	passim_item_set_file(item_file, gfile);
+	passim_item_set_bytes(item_file, file_bytes);
+	passim_item_set_basename(item_file, "client-test-file.bin");
+	passim_item_set_max_age(item_file, 3600);
+	passim_item_set_share_limit(item_file, 5);
+	if (!passim_client_publish(client, item_file, &error)) {
+		g_printerr("Failed to publish file: %s\n", error->message);
+		return 1;
+	}
+	g_unlink(tmpfile);
+
+	/* verify items appeared */
+	items2 = passim_client_get_items(client, &error);
+	if (items2 == NULL) {
+		g_printerr("Failed to get items after publish: %s\n", error->message);
+		return 1;
+	}
+	g_assert_cmpuint(items2->len, >, items->len);
+
+	/* unpublish both */
+	if (!passim_client_unpublish(client, hash_bytes_str, &error)) {
+		g_printerr("Failed to unpublish bytes item: %s\n", error->message);
+		return 1;
+	}
+
+	if (!passim_client_unpublish(client, hash_file_str, &error)) {
+		g_printerr("Failed to unpublish file item: %s\n", error->message);
+		return 1;
+	}
+
+	/* publish with no data should fail */
+	item_nodata = passim_item_new();
+	passim_item_set_basename(item_nodata, "no-data.bin");
+	g_assert_false(passim_client_publish(client, item_nodata, &error));
+	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+
+	return 0;
+}

--- a/src/passim-common.c
+++ b/src/passim-common.c
@@ -16,7 +16,7 @@
 #define PASSIM_CONFIG_PATH	    "Path"
 #define PASSIM_CONFIG_MAX_ITEM_SIZE "MaxItemSize"
 #define PASSIM_CONFIG_CARBON_COST   "CarbonCost"
-#define PASSIM_CONFIG_COOLDOWN   "Cooldown"
+#define PASSIM_CONFIG_COOLDOWN	    "Cooldown"
 
 const gchar *
 passim_status_to_string(PassimStatus status)
@@ -54,10 +54,7 @@ passim_config_load(GError **error)
 				      100 * 1024 * 1024);
 	}
 	if (!g_key_file_has_key(kf, PASSIM_CONFIG_GROUP, PASSIM_CONFIG_COOLDOWN, NULL)) {
-		g_key_file_set_integer(kf,
-				      PASSIM_CONFIG_GROUP,
-				      PASSIM_CONFIG_COOLDOWN,
-				      3600);
+		g_key_file_set_integer(kf, PASSIM_CONFIG_GROUP, PASSIM_CONFIG_COOLDOWN, 3600);
 	}
 	if (!g_key_file_has_key(kf, PASSIM_CONFIG_GROUP, PASSIM_CONFIG_PATH, NULL)) {
 		g_autofree gchar *path =

--- a/src/passim-integration-test.py
+++ b/src/passim-integration-test.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+#
+# Copyright 2023 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import hashlib
+import os
+import shutil
+import signal
+import socket
+import ssl
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.request
+import urllib.error
+
+try:
+    import dbus
+    import dbusmock
+except ImportError:
+    print("SKIP: python3-dbusmock not available", file=sys.stderr)
+    sys.exit(77)
+
+
+class PassimIntegrationTest(dbusmock.DBusTestCase):
+    """Integration test that starts a real passimd with mock Avahi."""
+
+    DAEMON_PORT = 27501
+    TEST_CONTENT = b"test data for passim integration testing"
+    TEST_BASENAME = "test-firmware.bin"
+    STATUS_RUNNING = 3
+
+    @classmethod
+    def setUpClass(cls):
+        cls.start_system_bus()
+        cls.test_hash = hashlib.sha256(cls.TEST_CONTENT).hexdigest()
+        cls.tmpdir = tempfile.mkdtemp(prefix="passim-test-")
+        cls.addClassCleanup(shutil.rmtree, cls.tmpdir, ignore_errors=True)
+
+        builddir = os.environ.get("PASSIM_BUILDDIR", "")
+        srcdir = os.environ.get("PASSIM_SRCDIR", "")
+
+        config_h = os.path.join(builddir, "config.h")
+        cls.sysconfdir = cls._parse_config_h(config_h, "PACKAGE_SYSCONFDIR")
+        cls.localstatedir = cls._parse_config_h(config_h, "PACKAGE_LOCALSTATEDIR")
+        cls.datadir = cls._parse_config_h(config_h, "PACKAGE_DATADIR")
+
+        cls._setup_directories()
+        cls._seed_audit_log()
+        cls._setup_sysconfpkgdir()
+        cls._setup_config()
+        cls._setup_tls_backups()
+        cls._install_dbus_interface(srcdir)
+        cls._start_mock_avahi()
+        cls._start_daemon(builddir)
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "daemon_proc") and cls.daemon_proc is not None:
+            cls.daemon_proc.send_signal(signal.SIGINT)
+            try:
+                cls.daemon_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                cls.daemon_proc.kill()
+                cls.daemon_proc.wait()
+
+        if hasattr(cls, "avahi_proc") and cls.avahi_proc is not None:
+            cls.avahi_proc.kill()
+            cls.avahi_proc.wait()
+
+        super().tearDownClass()
+
+    @staticmethod
+    def _parse_config_h(path, key):
+        with open(path, "r") as f:
+            for line in f:
+                if line.startswith(f"#define {key} "):
+                    return line.split('"')[1]
+        raise KeyError(f"{key} not found in {path}")
+
+    @classmethod
+    def _setup_directories(cls):
+        cls.data_path = os.path.join(cls.localstatedir, "lib", "passim", "data")
+        os.makedirs(cls.data_path, exist_ok=True)
+        cls.test_file = os.path.join(
+            cls.data_path, f"{cls.test_hash}-{cls.TEST_BASENAME}"
+        )
+        cls.addClassCleanup(cls._remove_if_exists, cls.test_file)
+        with open(cls.test_file, "wb") as f:
+            f.write(cls.TEST_CONTENT)
+
+        cls.log_path = os.path.join(cls.tmpdir, "logs")
+        os.makedirs(cls.log_path, exist_ok=True)
+
+    SEEDED_DOWNLOAD_SIZE = 42000
+
+    @classmethod
+    def _seed_audit_log(cls):
+        audit_file = os.path.join(cls.log_path, "audit.log")
+        fake_hash = "a" * 64
+        line = f"2026-01-01T00:00:00Z SHARE hash={fake_hash},basename=seeded.bin,size={cls.SEEDED_DOWNLOAD_SIZE},ipaddr=127.0.0.1\n"
+        with open(audit_file, "w") as f:
+            f.write(line)
+
+    SYSCONFPKG_CONTENT = b"sysconfpkgdir test file content"
+    SYSCONFPKG_BASENAME = "sysconfpkg-test.bin"
+
+    @classmethod
+    def _setup_sysconfpkgdir(cls):
+        cls.sysconfpkg_data = os.path.join(cls.tmpdir, "sysconfpkg-data")
+        os.makedirs(cls.sysconfpkg_data, exist_ok=True)
+        sysconfpkg_file = os.path.join(cls.sysconfpkg_data, cls.SYSCONFPKG_BASENAME)
+        with open(sysconfpkg_file, "wb") as f:
+            f.write(cls.SYSCONFPKG_CONTENT)
+        cls.sysconfpkg_hash = hashlib.sha256(cls.SYSCONFPKG_CONTENT).hexdigest()
+
+        passim_d = os.path.join(cls.sysconfdir, "passim.d")
+        os.makedirs(passim_d, exist_ok=True)
+
+        fd, cls.sysconfpkg_conf = tempfile.mkstemp(
+            suffix=".conf", prefix="passim-test-", dir=passim_d
+        )
+        cls.addClassCleanup(cls._remove_if_exists, cls.sysconfpkg_conf)
+        with os.fdopen(fd, "w") as f:
+            f.write(f"[passim]\nPath={cls.sysconfpkg_data}\n")
+
+        fd2, missing_conf = tempfile.mkstemp(
+            suffix=".conf", prefix="passim-missing-", dir=passim_d
+        )
+        cls.addClassCleanup(cls._remove_if_exists, missing_conf)
+        with os.fdopen(fd2, "w") as f:
+            f.write("[passim]\nPath=/nonexistent/path\n")
+
+    @classmethod
+    def _setup_config(cls):
+        conf_dir = cls.sysconfdir
+        os.makedirs(conf_dir, exist_ok=True)
+        cls.conf_file = os.path.join(conf_dir, "passim.conf")
+        conf_existed = os.path.exists(cls.conf_file)
+        if conf_existed:
+            cls.conf_backup = os.path.join(cls.tmpdir, "passim.conf.bak")
+            shutil.copy2(cls.conf_file, cls.conf_backup)
+            cls.addClassCleanup(shutil.move, cls.conf_backup, cls.conf_file)
+        else:
+            cls.addClassCleanup(cls._remove_if_exists, cls.conf_file)
+        with open(cls.conf_file, "w") as f:
+            f.write(f"[daemon]\nPort={cls.DAEMON_PORT}\n")
+
+    @staticmethod
+    def _remove_if_exists(path):
+        if os.path.exists(path):
+            os.unlink(path)
+
+    @classmethod
+    def _setup_tls_backups(cls):
+        tls_dir = os.path.join(cls.localstatedir, "lib", "passim")
+        for fn in ("secret.key", "cert.pem"):
+            path = os.path.join(tls_dir, fn)
+            if os.path.exists(path):
+                backup = os.path.join(cls.tmpdir, fn + ".bak")
+                shutil.copy2(path, backup)
+                cls.addClassCleanup(shutil.move, backup, path)
+            else:
+                cls.addClassCleanup(cls._remove_if_exists, path)
+
+    @classmethod
+    def _install_dbus_interface(cls, srcdir):
+        dbus_iface_dir = os.path.join(cls.datadir, "dbus-1", "interfaces")
+        os.makedirs(dbus_iface_dir, exist_ok=True)
+        dbus_iface_dst = os.path.join(
+            dbus_iface_dir, "org.freedesktop.Passim.xml"
+        )
+        dbus_iface_src = os.path.join(srcdir, "org.freedesktop.Passim.xml")
+        if not os.path.exists(dbus_iface_dst):
+            cls.addClassCleanup(cls._remove_if_exists, dbus_iface_dst)
+            shutil.copy2(dbus_iface_src, dbus_iface_dst)
+
+    @classmethod
+    def _start_mock_avahi(cls):
+        """Start a mock Avahi service on the mock system bus."""
+        cls.avahi_proc = cls.spawn_server(
+            "org.freedesktop.Avahi",
+            "/",
+            "org.freedesktop.Avahi.Server2",
+            system_bus=True,
+        )
+
+        bus = cls.get_dbus(system_bus=True)
+        avahi_root = bus.get_object("org.freedesktop.Avahi", "/")
+        avahi_mock = dbus.Interface(avahi_root, dbusmock.MOCK_IFACE)
+
+        avahi_mock.AddMethod(
+            "org.freedesktop.Avahi.Server2",
+            "EntryGroupNew",
+            "",
+            "o",
+            'ret = "/org/freedesktop/Avahi/EntryGroup/1"',
+        )
+
+        avahi_mock.AddObject(
+            "/org/freedesktop/Avahi/EntryGroup/1",
+            "org.freedesktop.Avahi.EntryGroup",
+            {},
+            [],
+        )
+
+        eg_obj = bus.get_object(
+            "org.freedesktop.Avahi",
+            "/org/freedesktop/Avahi/EntryGroup/1",
+        )
+        eg_mock = dbus.Interface(eg_obj, dbusmock.MOCK_IFACE)
+
+        for method, sig in [
+            ("Reset", ""),
+            ("AddService", "iiussssqaay"),
+            ("AddServiceSubtype", "iiussss"),
+            ("Commit", ""),
+        ]:
+            eg_mock.AddMethod(
+                "org.freedesktop.Avahi.EntryGroup", method, sig, "", ""
+            )
+
+        test_hash_prefix = cls.test_hash[:60]
+        avahi_mock.AddMethod(
+            "org.freedesktop.Avahi.Server2",
+            "ServiceBrowserPrepare",
+            "iissu",
+            "o",
+            f'if "_{test_hash_prefix}" in args[2]:\n'
+            '    ret = "/org/freedesktop/Avahi/ServiceBrowser/1"\n'
+            'else:\n'
+            '    ret = "/org/freedesktop/Avahi/ServiceBrowser/2"',
+        )
+
+        for sb_path in [
+            "/org/freedesktop/Avahi/ServiceBrowser/1",
+            "/org/freedesktop/Avahi/ServiceBrowser/2",
+        ]:
+            avahi_mock.AddObject(
+                sb_path,
+                "org.freedesktop.Avahi.ServiceBrowser",
+                {},
+                [],
+            )
+            sb_obj = bus.get_object("org.freedesktop.Avahi", sb_path)
+            sb_mock = dbus.Interface(sb_obj, dbusmock.MOCK_IFACE)
+            sb_mock.AddMethod(
+                "org.freedesktop.Avahi.ServiceBrowser",
+                "Free",
+                "",
+                "",
+                "",
+            )
+
+        sb1_obj = bus.get_object(
+            "org.freedesktop.Avahi",
+            "/org/freedesktop/Avahi/ServiceBrowser/1",
+        )
+        sb1_mock = dbus.Interface(sb1_obj, dbusmock.MOCK_IFACE)
+        sb1_mock.AddMethod(
+            "org.freedesktop.Avahi.ServiceBrowser",
+            "Start",
+            "",
+            "",
+            'import dbus\n'
+            'self.EmitSignal('
+            '"org.freedesktop.Avahi.ServiceBrowser", "ItemNew", "iisssu",'
+            ' [dbus.Int32(-1), dbus.Int32(0),'
+            ' dbus.String("Passim-Peer"),'
+            ' dbus.String("_cache._tcp"),'
+            ' dbus.String("local"), dbus.UInt32(0)])\n'
+            'self.EmitSignal('
+            '"org.freedesktop.Avahi.ServiceBrowser", "AllForNow", "", [])',
+        )
+
+        sb2_obj = bus.get_object(
+            "org.freedesktop.Avahi",
+            "/org/freedesktop/Avahi/ServiceBrowser/2",
+        )
+        sb2_mock = dbus.Interface(sb2_obj, dbusmock.MOCK_IFACE)
+        sb2_mock.AddMethod(
+            "org.freedesktop.Avahi.ServiceBrowser",
+            "Start",
+            "",
+            "",
+            'self.EmitSignal('
+            '"org.freedesktop.Avahi.ServiceBrowser", "AllForNow", "", [])',
+        )
+
+        avahi_mock.AddMethod(
+            "org.freedesktop.Avahi.Server2",
+            "ServiceResolverPrepare",
+            "iisssiu",
+            "o",
+            'ret = "/org/freedesktop/Avahi/ServiceResolver/1"',
+        )
+
+        avahi_mock.AddObject(
+            "/org/freedesktop/Avahi/ServiceResolver/1",
+            "org.freedesktop.Avahi.ServiceResolver",
+            {},
+            [],
+        )
+
+        sr_obj = bus.get_object(
+            "org.freedesktop.Avahi",
+            "/org/freedesktop/Avahi/ServiceResolver/1",
+        )
+        sr_mock = dbus.Interface(sr_obj, dbusmock.MOCK_IFACE)
+        sr_mock.AddMethod(
+            "org.freedesktop.Avahi.ServiceResolver",
+            "Start",
+            "",
+            "",
+            'import dbus\n'
+            'self.EmitSignal('
+            '"org.freedesktop.Avahi.ServiceResolver", "Found",'
+            ' "iissssisqaayu",'
+            ' [dbus.Int32(-1), dbus.Int32(0),'
+            ' dbus.String("Passim-Peer"),'
+            ' dbus.String("_cache._tcp"),'
+            ' dbus.String("local"),'
+            ' dbus.String("peer.local"), dbus.Int32(0),'
+            ' dbus.String("127.0.0.1"),'
+            f' dbus.UInt16({cls.DAEMON_PORT}),'
+            ' dbus.Array([], signature="ay"),'
+            ' dbus.UInt32(0)])',
+        )
+        sr_mock.AddMethod(
+            "org.freedesktop.Avahi.ServiceResolver", "Free", "", "", ""
+        )
+
+    @classmethod
+    def _start_daemon(cls, builddir):
+        """Start the passimd binary."""
+        daemon_path = os.path.join(builddir, "src", "passimd")
+        env = os.environ.copy()
+        env["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ.get(
+            "DBUS_SYSTEM_BUS_ADDRESS", ""
+        )
+        env["LOGS_DIRECTORY"] = cls.log_path
+        env["G_MESSAGES_DEBUG"] = "all"
+        env["G_DEBUG"] = ""
+
+        cls.daemon_proc = subprocess.Popen(
+            [daemon_path, "--insecure"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                s = socket.create_connection(
+                    ("127.0.0.1", cls.DAEMON_PORT), timeout=1
+                )
+                s.close()
+                return
+            except OSError:
+                rc = cls.daemon_proc.poll()
+                if rc is not None:
+                    raise RuntimeError(
+                        f"passimd exited with code {rc}"
+                    ) from None
+                time.sleep(0.2)
+
+        raise TimeoutError(
+            f"passimd did not start listening on port {cls.DAEMON_PORT}"
+        )
+
+    def _https_get(self, path, expected_status=200):
+        """Make an HTTPS GET request to the daemon."""
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        url = f"https://127.0.0.1:{self.DAEMON_PORT}{path}"
+        req = urllib.request.Request(url)
+        try:
+            with urllib.request.urlopen(req, context=ctx, timeout=10) as resp:
+                body = resp.read()
+                if expected_status != resp.status:
+                    self.fail(
+                        f"Expected {expected_status}, got {resp.status} for {path}"
+                    )
+                return resp.status, body, resp.headers
+        except urllib.error.HTTPError as e:
+            with e:
+                body = e.read()
+                if expected_status != e.code:
+                    self.fail(
+                        f"Expected {expected_status}, got {e.code} for {path}: "
+                        f"{body.decode(errors='replace')}"
+                    )
+                return e.code, body, e.headers
+
+    # -- HTTP tests --
+
+    def test_index_page(self):
+        status, body, headers = self._https_get("/")
+        self.assertEqual(status, 200)
+        html = body.decode()
+        self.assertIn(self.TEST_BASENAME, html)
+
+    def test_download_valid(self):
+        path = f"/{self.TEST_BASENAME}?sha256={self.test_hash}"
+        status, body, headers = self._https_get(path)
+        self.assertEqual(status, 200)
+        self.assertEqual(body, self.TEST_CONTENT)
+        self.assertIn("attachment", headers.get("Content-Disposition", ""))
+
+    def test_no_query_string(self):
+        status, body, _ = self._https_get("/somefile", expected_status=400)
+        self.assertEqual(status, 400)
+
+    def test_sha256_required(self):
+        status, body, _ = self._https_get(
+            "/somefile?foo=bar", expected_status=400
+        )
+        self.assertEqual(status, 400)
+
+    def test_duplicate_sha256(self):
+        h = "a" * 64
+        status, body, _ = self._https_get(
+            f"/file?sha256={h}&sha256={h}", expected_status=400
+        )
+        self.assertEqual(status, 400)
+
+    def test_malformed_sha256(self):
+        status, body, _ = self._https_get(
+            "/file?sha256=notahex", expected_status=406
+        )
+        self.assertEqual(status, 406)
+
+    def test_invalid_localhost_param(self):
+        status, body, _ = self._https_get(
+            f"/file?sha256={self.test_hash}&localhost=maybe",
+            expected_status=400,
+        )
+        self.assertEqual(status, 400)
+
+    def test_unknown_hash(self):
+        unknown = "b" * 64
+        status, body, _ = self._https_get(
+            f"/file?sha256={unknown}", expected_status=404
+        )
+        self.assertEqual(status, 404)
+
+    def test_sysconfpkgdir_item(self):
+        path = f"/{self.SYSCONFPKG_BASENAME}?sha256={self.sysconfpkg_hash}"
+        status, body, _ = self._https_get(path)
+        self.assertEqual(status, 200)
+        self.assertEqual(body, self.SYSCONFPKG_CONTENT)
+
+    # -- D-Bus tests --
+
+    def test_dbus_get_items(self):
+        bus = self.get_dbus(system_bus=True)
+        proxy = bus.get_object("org.freedesktop.Passim", "/")
+        iface = dbus.Interface(proxy, "org.freedesktop.Passim")
+        items = iface.GetItems()
+        self.assertIsInstance(items, dbus.Array)
+        self.assertGreater(len(items), 0)
+
+        found = False
+        for item_dict in items:
+            if "hash" in item_dict:
+                h = str(item_dict["hash"])
+                if h == self.test_hash:
+                    found = True
+                    break
+        self.assertTrue(found, f"Test item with hash {self.test_hash} not found")
+
+    def test_dbus_properties(self):
+        bus = self.get_dbus(system_bus=True)
+        proxy = bus.get_object("org.freedesktop.Passim", "/")
+        props = dbus.Interface(proxy, dbus.PROPERTIES_IFACE)
+
+        version = str(props.Get("org.freedesktop.Passim", "DaemonVersion"))
+        self.assertTrue(len(version) > 0)
+
+        status = int(props.Get("org.freedesktop.Passim", "Status"))
+        self.assertEqual(status, self.STATUS_RUNNING)
+
+        name = str(props.Get("org.freedesktop.Passim", "Name"))
+        self.assertTrue(name.startswith("Passim-"))
+
+        uri = str(props.Get("org.freedesktop.Passim", "Uri"))
+        self.assertIn(str(self.DAEMON_PORT), uri)
+
+    def test_download_saving(self):
+        bus = self.get_dbus(system_bus=True)
+        proxy = bus.get_object("org.freedesktop.Passim", "/")
+        props = dbus.Interface(proxy, dbus.PROPERTIES_IFACE)
+        saving = int(props.Get("org.freedesktop.Passim", "DownloadSaving"))
+        self.assertGreaterEqual(saving, self.SEEDED_DOWNLOAD_SIZE)
+
+    def test_dbus_publish_and_unpublish(self):
+        publish_content = b"published via dbus integration test"
+        publish_basename = "publish-test.bin"
+        publish_hash = hashlib.sha256(publish_content).hexdigest()
+
+        bus = self.get_dbus(system_bus=True)
+        proxy = bus.get_object("org.freedesktop.Passim", "/")
+        iface = dbus.Interface(proxy, "org.freedesktop.Passim")
+
+        with tempfile.NamedTemporaryFile() as tmp:
+            tmp.write(publish_content)
+            tmp.flush()
+            fd = os.open(tmp.name, os.O_RDONLY)
+            try:
+                attrs = dbus.Dictionary(
+                    {
+                        "filename": dbus.String(publish_basename),
+                        "share-limit": dbus.UInt32(5),
+                        "max-age": dbus.UInt32(3600),
+                    },
+                    signature="sv",
+                )
+                iface.Publish(dbus.types.UnixFd(fd), attrs)
+            finally:
+                os.close(fd)
+
+        items = iface.GetItems()
+        found = False
+        for item_dict in items:
+            if "hash" in item_dict:
+                if str(item_dict["hash"]) == publish_hash:
+                    found = True
+                    break
+        self.assertTrue(found, "Published item not found in GetItems")
+
+        path = f"/{publish_basename}?sha256={publish_hash}"
+        status, body, _ = self._https_get(path)
+        self.assertEqual(status, 200)
+        self.assertEqual(body, publish_content)
+
+        iface.Unpublish(publish_hash)
+
+        items = iface.GetItems()
+        found = False
+        for item_dict in items:
+            if "hash" in item_dict:
+                if str(item_dict["hash"]) == publish_hash:
+                    found = True
+                    break
+        self.assertFalse(found, "Unpublished item still in GetItems")
+
+    def test_client_api(self):
+        helper = os.environ.get("PASSIM_CLIENT_TEST_HELPER", "")
+        if not helper or not os.path.exists(helper):
+            self.skipTest("PASSIM_CLIENT_TEST_HELPER not set or not found")
+        env = os.environ.copy()
+        env["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ.get(
+            "DBUS_SYSTEM_BUS_ADDRESS", ""
+        )
+        result = subprocess.run(
+            [helper],
+            env=env,
+            capture_output=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0)
+
+    def test_dbus_unpublish_not_found(self):
+        bus = self.get_dbus(system_bus=True)
+        proxy = bus.get_object("org.freedesktop.Passim", "/")
+        iface = dbus.Interface(proxy, "org.freedesktop.Passim")
+
+        with self.assertRaises(dbus.exceptions.DBusException):
+            iface.Unpublish("c" * 64)
+
+    # -- CLI tests --
+
+    def _run_cli(self, args, cwd=None):
+        cli = os.environ.get("PASSIM_CLI", "")
+        if not cli or not os.path.exists(cli):
+            self.skipTest("PASSIM_CLI not set or not found")
+        env = os.environ.copy()
+        env["DBUS_SYSTEM_BUS_ADDRESS"] = os.environ.get(
+            "DBUS_SYSTEM_BUS_ADDRESS", ""
+        )
+        return subprocess.run(
+            [cli] + args,
+            env=env,
+            capture_output=True,
+            timeout=30,
+            cwd=cwd,
+        )
+
+    def test_cli_version(self):
+        result = self._run_cli(["--version"])
+        self.assertEqual(result.returncode, 0)
+        stdout = result.stdout.decode()
+        self.assertIn("client version", stdout)
+        self.assertIn("daemon version", stdout)
+
+    def test_cli_status(self):
+        result = self._run_cli(["status"])
+        self.assertEqual(result.returncode, 0)
+        stdout = result.stdout.decode()
+        self.assertIn(self.TEST_BASENAME, stdout)
+
+    def test_cli_publish_and_unpublish(self):
+        cli_content = b"passim cli publish test data"
+        cli_hash = hashlib.sha256(cli_content).hexdigest()
+        with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tmp:
+            tmp.write(cli_content)
+            tmp_path = tmp.name
+        try:
+            result = self._run_cli(["publish", tmp_path])
+            self.assertEqual(result.returncode, 0)
+            stdout = result.stdout.decode()
+            self.assertIn("Published", stdout)
+        finally:
+            os.unlink(tmp_path)
+
+        result = self._run_cli(["unpublish", cli_hash])
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Unpublished", result.stdout.decode())
+
+    def test_cli_unpublish_bad_hash(self):
+        result = self._run_cli(["unpublish", "d" * 64])
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_download_via_peer(self):
+        path = f"/{self.TEST_BASENAME}?sha256={self.test_hash}&localhost=false"
+        status, body, headers = self._https_get(path)
+        self.assertEqual(status, 200)
+        self.assertEqual(body, self.TEST_CONTENT)
+
+    def test_cli_download(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self._run_cli(
+                ["download", self.TEST_BASENAME, self.test_hash], cwd=tmpdir
+            )
+            self.assertEqual(result.returncode, 0)
+            stdout = result.stdout.decode()
+            self.assertIn("Saved", stdout)
+            downloaded = os.path.join(tmpdir, self.TEST_BASENAME)
+            with open(downloaded, "rb") as f:
+                self.assertEqual(f.read(), self.TEST_CONTENT)
+
+    def test_cli_unknown_command(self):
+        result = self._run_cli(["badcommand"])
+        self.assertNotEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/passim-self-test.c
+++ b/src/passim-self-test.c
@@ -8,42 +8,10 @@
 
 #include <glib/gstdio.h>
 #include <passim.h>
+#include <string.h>
 
 #include "passim-common.h"
-
-#if 0
-static GMainLoop *_test_loop = NULL;
-static guint _test_loop_timeout_id = 0;
-
-static gboolean
-passim_test_hang_check_cb(gpointer user_data)
-{
-	g_main_loop_quit(_test_loop);
-	_test_loop_timeout_id = 0;
-	return G_SOURCE_REMOVE;
-}
-
-static void
-passim_test_loop_run_with_timeout(guint timeout_ms)
-{
-	g_assert_cmpint(_test_loop_timeout_id, ==, 0);
-	g_assert_null(_test_loop);
-	_test_loop = g_main_loop_new(NULL, FALSE);
-	_test_loop_timeout_id = g_timeout_add(timeout_ms, passim_test_hang_check_cb, NULL);
-	g_main_loop_run(_test_loop);
-}
-
-static void
-passim_test_loop_quit(void)
-{
-	g_clear_handle_id (&_test_loop_timeout_id, g_source_remove);
-	if (_test_loop != NULL) {
-		g_main_loop_quit(_test_loop);
-		g_main_loop_unref(_test_loop);
-		_test_loop = NULL;
-	}
-}
-#endif
+#include "passim-gnutls.h"
 
 static void
 passim_common_func(void)
@@ -78,6 +46,13 @@ passim_common_func(void)
 	g_test_assert_expected_messages();
 	g_assert_cmpint(port, ==, 27500);
 
+	/* zero port should fall back to default */
+	g_key_file_set_integer(kf, "daemon", "Port", 0);
+	g_test_expect_message(NULL, G_LOG_LEVEL_WARNING, "invalid port*");
+	port = passim_config_get_port(kf);
+	g_test_assert_expected_messages();
+	g_assert_cmpint(port, ==, 27500);
+
 	/* valid sha256 hash */
 	g_assert_true(passim_is_valid_sha256(
 	    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
@@ -91,6 +66,9 @@ passim_common_func(void)
 
 	/* NULL hash */
 	g_assert_false(passim_is_valid_sha256(NULL));
+
+	/* empty string hash */
+	g_assert_false(passim_is_valid_sha256(""));
 
 	/* ensure we got *something* */
 	boot_time = passim_get_boot_time();
@@ -135,6 +113,652 @@ passim_common_func(void)
 	g_assert_cmpstr(value_str2, ==, "");
 }
 
+static void
+passim_common_status_func(void)
+{
+	g_assert_cmpstr(passim_status_to_string(PASSIM_STATUS_STARTING), ==, "starting");
+	g_assert_cmpstr(passim_status_to_string(PASSIM_STATUS_LOADING), ==, "loading");
+	g_assert_cmpstr(passim_status_to_string(PASSIM_STATUS_DISABLED_METERED),
+			==,
+			"disabled-metered");
+	g_assert_cmpstr(passim_status_to_string(PASSIM_STATUS_RUNNING), ==, "running");
+	g_assert_null(passim_status_to_string(PASSIM_STATUS_UNKNOWN));
+}
+
+static void
+passim_common_config_func(void)
+{
+	gdouble cost;
+	g_autofree gchar *path = NULL;
+	g_autoptr(GKeyFile) kf = g_key_file_new();
+	g_autoptr(GKeyFile) kf2 = g_key_file_new();
+
+	/* ipv6 defaults to false when not set */
+	g_assert_false(passim_config_get_ipv6(kf));
+
+	/* ipv6 set to true */
+	g_key_file_set_boolean(kf, "daemon", "IPv6", TRUE);
+	g_assert_true(passim_config_get_ipv6(kf));
+
+	/* max item size */
+	g_key_file_set_uint64(kf, "daemon", "MaxItemSize", 5000);
+	g_assert_cmpuint(passim_config_get_max_item_size(kf), ==, 5000);
+
+	/* cooldown */
+	g_key_file_set_integer(kf, "daemon", "Cooldown", 7200);
+	g_assert_cmpint(passim_config_get_cooldown(kf), ==, 7200);
+
+	/* carbon cost -- default when not set */
+	cost = passim_config_get_carbon_cost(kf2);
+	g_assert_cmpfloat(cost, >, 0.02);
+	g_assert_cmpfloat(cost, <, 0.03);
+
+	/* carbon cost -- custom value */
+	g_key_file_set_double(kf, "daemon", "CarbonCost", 0.05);
+	g_assert_cmpfloat(passim_config_get_carbon_cost(kf), ==, 0.05);
+
+	/* path */
+	g_key_file_set_string(kf, "daemon", "Path", "/tmp/test");
+	path = passim_config_get_path(kf);
+	g_assert_cmpstr(path, ==, "/tmp/test");
+}
+
+static void
+passim_common_mkdir_parent_func(void)
+{
+	gboolean ret;
+	g_autofree gchar *fn = NULL;
+	g_autofree gchar *parent = NULL;
+	g_autoptr(GError) error = NULL;
+
+	fn = g_test_build_filename(G_TEST_BUILT, "tests", "subdir", "file.txt", NULL);
+	ret = passim_mkdir_parent(fn, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	parent = g_path_get_dirname(fn);
+	g_assert_true(g_file_test(parent, G_FILE_TEST_IS_DIR));
+}
+
+static void
+passim_common_file_contents_func(void)
+{
+	gboolean ret;
+	const gchar *data;
+	gsize size;
+	g_autofree gchar *fn = NULL;
+	g_autoptr(GBytes) bytes_in = NULL;
+	g_autoptr(GBytes) bytes_out = NULL;
+	g_autoptr(GError) error = NULL;
+
+	fn = g_test_build_filename(G_TEST_BUILT, "tests", "file-contents-test.bin", NULL);
+	ret = passim_mkdir_parent(fn, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* write */
+	bytes_in = g_bytes_new_static("hello world", 11);
+	ret = passim_file_set_contents(fn, bytes_in, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* read back */
+	bytes_out = passim_file_get_contents(fn, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(bytes_out);
+	data = g_bytes_get_data(bytes_out, &size);
+	g_assert_cmpuint(size, ==, 11);
+	g_assert_cmpmem(data, size, "hello world", 11);
+
+	(void)g_unlink(fn);
+}
+
+static void
+passim_common_load_input_stream_func(void)
+{
+	g_autoptr(GBytes) bytes = NULL;
+	g_autoptr(GBytes) bytes2 = NULL;
+	g_autoptr(GBytes) bytes3 = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GError) error2 = NULL;
+	g_autoptr(GError) error3 = NULL;
+	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(GInputStream) stream2 = NULL;
+	g_autoptr(GInputStream) stream3 = NULL;
+
+	/* normal read */
+	stream = g_memory_input_stream_new_from_data("test data", 9, NULL);
+	bytes = passim_load_input_stream(stream, 1024, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(bytes);
+	g_assert_cmpuint(g_bytes_get_size(bytes), ==, 9);
+
+	/* zero count should fail */
+	stream2 = g_memory_input_stream_new_from_data("test", 4, NULL);
+	bytes2 = passim_load_input_stream(stream2, 0, &error2);
+	g_assert_error(error2, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED);
+	g_assert_null(bytes2);
+
+	/* stream larger than count should fail */
+	stream3 = g_memory_input_stream_new_from_data("abcdefghij", 10, NULL);
+	bytes3 = passim_load_input_stream(stream3, 5, &error3);
+	g_assert_error(error3, G_IO_ERROR, G_IO_ERROR_NO_SPACE);
+	g_assert_null(bytes3);
+}
+
+static void
+passim_item_func(void)
+{
+	g_autoptr(PassimItem) item = passim_item_new();
+
+	/* defaults */
+	g_assert_null(passim_item_get_hash(item));
+	g_assert_null(passim_item_get_basename(item));
+	g_assert_null(passim_item_get_cmdline(item));
+	g_assert_cmpuint(passim_item_get_flags(item), ==, PASSIM_ITEM_FLAG_NONE);
+	g_assert_null(passim_item_get_file(item));
+	g_assert_null(passim_item_get_bytes(item));
+	g_assert_null(passim_item_get_stream(item));
+	g_assert_null(passim_item_get_ctime(item));
+	g_assert_cmpuint(passim_item_get_share_count(item), ==, 0);
+
+	/* default max_age is 24h */
+	g_assert_cmpuint(passim_item_get_max_age(item), ==, 24 * 60 * 60);
+
+	/* default share_limit is 5 */
+	g_assert_cmpuint(passim_item_get_share_limit(item), ==, 5);
+
+	/* size defaults to 0 */
+	g_assert_cmpuint(passim_item_get_size(item), ==, 0);
+
+	/* set and get hash */
+	passim_item_set_hash(item, "abc123");
+	g_assert_cmpstr(passim_item_get_hash(item), ==, "abc123");
+
+	/* set same value -- no-op */
+	passim_item_set_hash(item, "abc123");
+	g_assert_cmpstr(passim_item_get_hash(item), ==, "abc123");
+
+	/* set different value */
+	passim_item_set_hash(item, "def456");
+	g_assert_cmpstr(passim_item_get_hash(item), ==, "def456");
+
+	/* basename */
+	passim_item_set_basename(item, "firmware.bin");
+	g_assert_cmpstr(passim_item_get_basename(item), ==, "firmware.bin");
+
+	/* set same basename -- no-op */
+	passim_item_set_basename(item, "firmware.bin");
+	g_assert_cmpstr(passim_item_get_basename(item), ==, "firmware.bin");
+
+	/* cmdline */
+	passim_item_set_cmdline(item, "/usr/bin/fwupd");
+	g_assert_cmpstr(passim_item_get_cmdline(item), ==, "/usr/bin/fwupd");
+
+	/* set same cmdline -- no-op */
+	passim_item_set_cmdline(item, "/usr/bin/fwupd");
+	g_assert_cmpstr(passim_item_get_cmdline(item), ==, "/usr/bin/fwupd");
+
+	/* max_age */
+	passim_item_set_max_age(item, 3600);
+	g_assert_cmpuint(passim_item_get_max_age(item), ==, 3600);
+
+	/* share_limit */
+	passim_item_set_share_limit(item, 10);
+	g_assert_cmpuint(passim_item_get_share_limit(item), ==, 10);
+
+	/* share_count */
+	passim_item_set_share_count(item, 3);
+	g_assert_cmpuint(passim_item_get_share_count(item), ==, 3);
+
+	/* size */
+	passim_item_set_size(item, 1024);
+	g_assert_cmpuint(passim_item_get_size(item), ==, 1024);
+}
+
+static void
+passim_item_flags_func(void)
+{
+	g_autofree gchar *str_multiple = NULL;
+	g_autofree gchar *str_none = NULL;
+	g_autofree gchar *str_single = NULL;
+	g_autoptr(PassimItem) item = passim_item_new();
+
+	/* initial state */
+	g_assert_cmpuint(passim_item_get_flags(item), ==, PASSIM_ITEM_FLAG_NONE);
+	g_assert_false(passim_item_has_flag(item, PASSIM_ITEM_FLAG_DISABLED));
+	g_assert_false(passim_item_has_flag(item, PASSIM_ITEM_FLAG_NEXT_REBOOT));
+
+	/* add flag */
+	passim_item_add_flag(item, PASSIM_ITEM_FLAG_DISABLED);
+	g_assert_true(passim_item_has_flag(item, PASSIM_ITEM_FLAG_DISABLED));
+	g_assert_cmpuint(passim_item_get_flags(item), ==, PASSIM_ITEM_FLAG_DISABLED);
+
+	/* add same flag again -- no-op */
+	passim_item_add_flag(item, PASSIM_ITEM_FLAG_DISABLED);
+	g_assert_true(passim_item_has_flag(item, PASSIM_ITEM_FLAG_DISABLED));
+
+	/* add another flag */
+	passim_item_add_flag(item, PASSIM_ITEM_FLAG_NEXT_REBOOT);
+	g_assert_true(passim_item_has_flag(item, PASSIM_ITEM_FLAG_DISABLED));
+	g_assert_true(passim_item_has_flag(item, PASSIM_ITEM_FLAG_NEXT_REBOOT));
+
+	/* add NONE flag -- no-op */
+	passim_item_add_flag(item, PASSIM_ITEM_FLAG_NONE);
+	g_assert_true(passim_item_has_flag(item, PASSIM_ITEM_FLAG_DISABLED));
+
+	/* remove flag */
+	passim_item_remove_flag(item, PASSIM_ITEM_FLAG_DISABLED);
+	g_assert_false(passim_item_has_flag(item, PASSIM_ITEM_FLAG_DISABLED));
+	g_assert_true(passim_item_has_flag(item, PASSIM_ITEM_FLAG_NEXT_REBOOT));
+
+	/* remove flag that's not set -- no-op */
+	passim_item_remove_flag(item, PASSIM_ITEM_FLAG_DISABLED);
+	g_assert_false(passim_item_has_flag(item, PASSIM_ITEM_FLAG_DISABLED));
+
+	/* remove NONE flag -- no-op */
+	passim_item_remove_flag(item, PASSIM_ITEM_FLAG_NONE);
+
+	/* set flags directly */
+	passim_item_set_flags(item, PASSIM_ITEM_FLAG_DISABLED | PASSIM_ITEM_FLAG_NEXT_REBOOT);
+	g_assert_cmpuint(passim_item_get_flags(item),
+			 ==,
+			 PASSIM_ITEM_FLAG_DISABLED | PASSIM_ITEM_FLAG_NEXT_REBOOT);
+
+	/* set same flags -- no-op */
+	passim_item_set_flags(item, PASSIM_ITEM_FLAG_DISABLED | PASSIM_ITEM_FLAG_NEXT_REBOOT);
+	g_assert_cmpuint(passim_item_get_flags(item),
+			 ==,
+			 PASSIM_ITEM_FLAG_DISABLED | PASSIM_ITEM_FLAG_NEXT_REBOOT);
+
+	/* flags as string -- multiple */
+	str_multiple = passim_item_get_flags_as_string(item);
+	g_assert_cmpstr(str_multiple, ==, "disabled,next-reboot");
+
+	/* flags as string -- none */
+	passim_item_set_flags(item, PASSIM_ITEM_FLAG_NONE);
+	str_none = passim_item_get_flags_as_string(item);
+	g_assert_cmpstr(str_none, ==, "none");
+
+	/* flags as string -- single */
+	passim_item_set_flags(item, PASSIM_ITEM_FLAG_NEXT_REBOOT);
+	str_single = passim_item_get_flags_as_string(item);
+	g_assert_cmpstr(str_single, ==, "next-reboot");
+}
+
+static void
+passim_item_flag_string_func(void)
+{
+	/* to string */
+	g_assert_cmpstr(passim_item_flag_to_string(PASSIM_ITEM_FLAG_NONE), ==, "none");
+	g_assert_cmpstr(passim_item_flag_to_string(PASSIM_ITEM_FLAG_DISABLED), ==, "disabled");
+	g_assert_cmpstr(passim_item_flag_to_string(PASSIM_ITEM_FLAG_NEXT_REBOOT),
+			==,
+			"next-reboot");
+	g_assert_null(passim_item_flag_to_string(PASSIM_ITEM_FLAG_UNKNOWN));
+
+	/* from string */
+	g_assert_cmpuint(passim_item_flag_from_string("none"), ==, PASSIM_ITEM_FLAG_NONE);
+	g_assert_cmpuint(passim_item_flag_from_string("disabled"), ==, PASSIM_ITEM_FLAG_DISABLED);
+	g_assert_cmpuint(passim_item_flag_from_string("next-reboot"),
+			 ==,
+			 PASSIM_ITEM_FLAG_NEXT_REBOOT);
+	g_assert_cmpuint(passim_item_flag_from_string("invalid"), ==, PASSIM_ITEM_FLAG_UNKNOWN);
+	g_assert_cmpuint(passim_item_flag_from_string(NULL), ==, PASSIM_ITEM_FLAG_UNKNOWN);
+}
+
+static void
+passim_item_bytes_func(void)
+{
+	g_autoptr(PassimItem) item = passim_item_new();
+	g_autoptr(GBytes) bytes = g_bytes_new_static("hello", 5);
+
+	/* setting bytes should auto-set hash and size */
+	g_assert_null(passim_item_get_hash(item));
+	g_assert_cmpuint(passim_item_get_size(item), ==, 0);
+
+	passim_item_set_bytes(item, bytes);
+	g_assert_nonnull(passim_item_get_hash(item));
+	g_assert_cmpuint(passim_item_get_size(item), ==, 5);
+	g_assert_nonnull(passim_item_get_bytes(item));
+
+	/* verify it's a valid sha256 hash */
+	g_assert_true(passim_is_valid_sha256(passim_item_get_hash(item)));
+
+	/* set same bytes -- no-op */
+	passim_item_set_bytes(item, bytes);
+	g_assert_cmpuint(passim_item_get_size(item), ==, 5);
+
+	/* clear bytes */
+	passim_item_set_bytes(item, NULL);
+	g_assert_null(passim_item_get_bytes(item));
+}
+
+static void
+passim_item_file_func(void)
+{
+	g_autoptr(PassimItem) item = passim_item_new();
+	g_autoptr(GFile) file = g_file_new_for_path("/tmp/firmware.bin");
+
+	/* setting file should auto-set basename */
+	g_assert_null(passim_item_get_basename(item));
+	passim_item_set_file(item, file);
+	g_assert_cmpstr(passim_item_get_basename(item), ==, "firmware.bin");
+	g_assert_nonnull(passim_item_get_file(item));
+}
+
+static void
+passim_item_ctime_func(void)
+{
+	g_autoptr(GDateTime) dt = g_date_time_new_utc(2023, 6, 15, 12, 0, 0);
+	g_autoptr(GDateTime) dt2 = g_date_time_new_utc(2024, 1, 1, 0, 0, 0);
+	g_autoptr(PassimItem) item = passim_item_new();
+
+	/* initially null */
+	g_assert_null(passim_item_get_ctime(item));
+	g_assert_cmpuint(passim_item_get_age(item), ==, 0);
+
+	/* set and get */
+	passim_item_set_ctime(item, dt);
+	g_assert_nonnull(passim_item_get_ctime(item));
+
+	/* age should be non-zero for a date in the past */
+	g_assert_cmpuint(passim_item_get_age(item), >, 0);
+
+	/* set same -- no-op */
+	passim_item_set_ctime(item, passim_item_get_ctime(item));
+	g_assert_nonnull(passim_item_get_ctime(item));
+
+	/* change to different time */
+	passim_item_set_ctime(item, dt2);
+	g_assert_nonnull(passim_item_get_ctime(item));
+
+	/* clear */
+	passim_item_set_ctime(item, NULL);
+	g_assert_null(passim_item_get_ctime(item));
+}
+
+static void
+passim_item_variant_func(void)
+{
+	g_autoptr(PassimItem) item = passim_item_new();
+	g_autoptr(PassimItem) item2 = NULL;
+	g_autoptr(GVariant) variant = NULL;
+	g_autoptr(GDateTime) dt = g_date_time_new_utc(2023, 6, 15, 12, 0, 0);
+
+	/* populate item */
+	passim_item_set_hash(item,
+			     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+	passim_item_set_basename(item, "test.bin");
+	passim_item_set_cmdline(item, "/usr/bin/test");
+	passim_item_set_max_age(item, 7200);
+	passim_item_set_share_limit(item, 10);
+	passim_item_set_share_count(item, 3);
+	passim_item_set_size(item, 4096);
+	passim_item_set_flags(item, PASSIM_ITEM_FLAG_DISABLED | PASSIM_ITEM_FLAG_NEXT_REBOOT);
+	passim_item_set_ctime(item, dt);
+
+	/* serialize */
+	variant = passim_item_to_variant(item);
+	g_assert_nonnull(variant);
+
+	/* deserialize */
+	item2 = passim_item_from_variant(variant);
+	g_assert_nonnull(item2);
+
+	/* verify all fields round-trip */
+	g_assert_cmpstr(passim_item_get_hash(item2),
+			==,
+			"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+	g_assert_cmpstr(passim_item_get_basename(item2), ==, "test.bin");
+	g_assert_cmpstr(passim_item_get_cmdline(item2), ==, "/usr/bin/test");
+	g_assert_cmpuint(passim_item_get_max_age(item2), ==, 7200);
+	g_assert_cmpuint(passim_item_get_share_limit(item2), ==, 10);
+	g_assert_cmpuint(passim_item_get_share_count(item2), ==, 3);
+	g_assert_cmpuint(passim_item_get_size(item2), ==, 4096);
+	g_assert_cmpuint(passim_item_get_flags(item2),
+			 ==,
+			 PASSIM_ITEM_FLAG_DISABLED | PASSIM_ITEM_FLAG_NEXT_REBOOT);
+	g_assert_nonnull(passim_item_get_ctime(item2));
+}
+
+static void
+passim_item_variant_empty_func(void)
+{
+	g_autoptr(PassimItem) item = passim_item_new();
+	g_autoptr(PassimItem) item2 = NULL;
+	g_autoptr(GVariant) variant = NULL;
+
+	/* serialize item with only defaults */
+	variant = passim_item_to_variant(item);
+	g_assert_nonnull(variant);
+
+	/* deserialize */
+	item2 = passim_item_from_variant(variant);
+	g_assert_nonnull(item2);
+	g_assert_null(passim_item_get_hash(item2));
+	g_assert_null(passim_item_get_basename(item2));
+	g_assert_null(passim_item_get_cmdline(item2));
+}
+
+static void
+passim_item_to_string_func(void)
+{
+	g_autoptr(PassimItem) item = passim_item_new();
+	g_autofree gchar *str = NULL;
+
+	passim_item_set_hash(item,
+			     "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890");
+	passim_item_set_basename(item, "test.bin");
+	passim_item_set_cmdline(item, "fwupd");
+	passim_item_set_size(item, 1024);
+	passim_item_set_flags(item, PASSIM_ITEM_FLAG_DISABLED);
+
+	str = passim_item_to_string(item);
+	g_assert_nonnull(str);
+	g_assert_true(
+	    g_str_has_prefix(str,
+			     "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"));
+	g_assert_nonnull(g_strstr_len(str, -1, "test.bin"));
+	g_assert_nonnull(g_strstr_len(str, -1, "flags:disabled"));
+	g_assert_nonnull(g_strstr_len(str, -1, "cmdline:fwupd"));
+	g_assert_nonnull(g_strstr_len(str, -1, "size:"));
+}
+
+static void
+passim_item_to_string_share_func(void)
+{
+	g_autoptr(PassimItem) item = passim_item_new();
+	g_autofree gchar *str = NULL;
+
+	passim_item_set_hash(item,
+			     "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890");
+	passim_item_set_basename(item, "test.bin");
+	passim_item_set_max_age(item, 3600);
+	passim_item_set_share_limit(item, 10);
+	passim_item_set_share_count(item, 2);
+
+	str = passim_item_to_string(item);
+	g_assert_nonnull(str);
+	g_assert_nonnull(g_strstr_len(str, -1, "share:2/10"));
+}
+
+static void
+passim_item_load_filename_func(void)
+{
+	gboolean ret;
+	g_autoptr(PassimItem) item = passim_item_new();
+	g_autofree gchar *fn = NULL;
+	g_autoptr(GError) error = NULL;
+
+	fn = g_test_build_filename(G_TEST_BUILT, "tests", "load-test.bin", NULL);
+	ret = passim_mkdir_parent(fn, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* create a test file */
+	ret = g_file_set_contents(fn, "test content for load", -1, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* load */
+	ret = passim_item_load_filename(item, fn, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* should have auto-set various properties */
+	g_assert_nonnull(passim_item_get_hash(item));
+	g_assert_true(passim_is_valid_sha256(passim_item_get_hash(item)));
+	g_assert_nonnull(passim_item_get_bytes(item));
+	g_assert_cmpuint(passim_item_get_size(item), ==, 21);
+	g_assert_cmpstr(passim_item_get_basename(item), ==, "load-test.bin");
+	g_assert_nonnull(passim_item_get_file(item));
+
+	/* load again -- should be no-op since already loaded */
+	ret = passim_item_load_filename(item, fn, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	(void)g_unlink(fn);
+}
+
+static void
+passim_gnutls_create_private_key_func(void)
+{
+	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(GError) error = NULL;
+
+	blob = passim_gnutls_create_private_key(&error);
+	g_assert_no_error(error);
+	g_assert_nonnull(blob);
+	g_assert_cmpuint(g_bytes_get_size(blob), >, 100);
+	g_assert_cmpint(memcmp(g_bytes_get_data(blob, NULL), "-----BEGIN ", 11), ==, 0);
+}
+
+static void
+passim_gnutls_load_privkey_func(void)
+{
+	g_autoptr(GBytes) bad = g_bytes_new_static("not a key", 9);
+	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GError) error2 = NULL;
+	g_auto(gnutls_privkey_t) bad_key = NULL;
+	g_auto(gnutls_privkey_t) privkey = NULL;
+
+	/* generate and load */
+	blob = passim_gnutls_create_private_key(&error);
+	g_assert_no_error(error);
+	privkey = passim_gnutls_load_privkey_from_blob(blob, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(privkey);
+
+	/* error path: invalid data */
+	bad_key = passim_gnutls_load_privkey_from_blob(bad, &error2);
+	g_assert_error(error2, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_null(bad_key);
+}
+
+static void
+passim_gnutls_create_certificate_func(void)
+{
+	g_autoptr(GBytes) key_blob = NULL;
+	g_autoptr(GBytes) cert_blob = NULL;
+	g_autoptr(GError) error = NULL;
+	g_auto(gnutls_privkey_t) privkey = NULL;
+
+	key_blob = passim_gnutls_create_private_key(&error);
+	g_assert_no_error(error);
+	privkey = passim_gnutls_load_privkey_from_blob(key_blob, &error);
+	g_assert_no_error(error);
+
+	cert_blob = passim_gnutls_create_certificate(privkey, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(cert_blob);
+	g_assert_cmpuint(g_bytes_get_size(cert_blob), >, 100);
+	g_assert_cmpint(memcmp(g_bytes_get_data(cert_blob, NULL), "-----BEGIN ", 11), ==, 0);
+}
+
+static void
+passim_gnutls_load_crt_func(void)
+{
+	g_autoptr(GBytes) bad = g_bytes_new_static("not a cert", 10);
+	g_autoptr(GBytes) cert_blob = NULL;
+	g_autoptr(GBytes) key_blob = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GError) error2 = NULL;
+	g_auto(gnutls_privkey_t) privkey = NULL;
+	g_auto(gnutls_x509_crt_t) bad_crt = NULL;
+	g_auto(gnutls_x509_crt_t) crt = NULL;
+
+	/* generate key and cert, then load the cert back */
+	key_blob = passim_gnutls_create_private_key(&error);
+	g_assert_no_error(error);
+	privkey = passim_gnutls_load_privkey_from_blob(key_blob, &error);
+	g_assert_no_error(error);
+	cert_blob = passim_gnutls_create_certificate(privkey, &error);
+	g_assert_no_error(error);
+
+	crt = passim_gnutls_load_crt_from_blob(cert_blob, GNUTLS_X509_FMT_PEM, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(crt);
+
+	/* error path: invalid data */
+	bad_crt = passim_gnutls_load_crt_from_blob(bad, GNUTLS_X509_FMT_PEM, &error2);
+	g_assert_error(error2, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_null(bad_crt);
+}
+
+static void
+passim_gnutls_pubkey_func(void)
+{
+	g_autoptr(GBytes) key_blob = NULL;
+	g_autoptr(GError) error = NULL;
+	g_auto(gnutls_privkey_t) privkey = NULL;
+	g_auto(gnutls_pubkey_t) pubkey = NULL;
+
+	key_blob = passim_gnutls_create_private_key(&error);
+	g_assert_no_error(error);
+	privkey = passim_gnutls_load_privkey_from_blob(key_blob, &error);
+	g_assert_no_error(error);
+	pubkey = passim_gnutls_load_pubkey_from_privkey(privkey, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(pubkey);
+}
+
+static void
+passim_gnutls_datum_to_dn_str_func(void)
+{
+	g_autofree gchar *str = NULL;
+	gnutls_datum_t raw = {0};
+
+	/* empty datum should return NULL (import fails) */
+	str = passim_gnutls_datum_to_dn_str(&raw);
+	g_assert_null(str);
+}
+
+static void
+passim_client_func(void)
+{
+	g_autoptr(PassimClient) client = passim_client_new();
+
+	/* initial state */
+	g_assert_nonnull(client);
+	g_assert_null(passim_client_get_version(client));
+	g_assert_null(passim_client_get_name(client));
+	g_assert_null(passim_client_get_uri(client));
+	g_assert_cmpint(passim_client_get_status(client), ==, PASSIM_STATUS_UNKNOWN);
+	g_assert_cmpuint(passim_client_get_download_saving(client), ==, 0);
+	g_assert_cmpfloat(passim_client_get_carbon_saving(client), ==, 0.0);
+}
+
+static void
+passim_version_func(void)
+{
+	const gchar *ver = passim_version_string();
+	g_assert_nonnull(ver);
+	g_assert_true(g_strstr_len(ver, -1, ".") != NULL);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -147,5 +771,29 @@ main(int argc, char **argv)
 	(void)g_setenv("G_MESSAGES_DEBUG", "all", TRUE);
 
 	g_test_add_func("/passim/common", passim_common_func);
+	g_test_add_func("/passim/common/status", passim_common_status_func);
+	g_test_add_func("/passim/common/config", passim_common_config_func);
+	g_test_add_func("/passim/common/mkdir-parent", passim_common_mkdir_parent_func);
+	g_test_add_func("/passim/common/file-contents", passim_common_file_contents_func);
+	g_test_add_func("/passim/common/load-input-stream", passim_common_load_input_stream_func);
+	g_test_add_func("/passim/item", passim_item_func);
+	g_test_add_func("/passim/item/flags", passim_item_flags_func);
+	g_test_add_func("/passim/item/flag-string", passim_item_flag_string_func);
+	g_test_add_func("/passim/item/bytes", passim_item_bytes_func);
+	g_test_add_func("/passim/item/file", passim_item_file_func);
+	g_test_add_func("/passim/item/ctime", passim_item_ctime_func);
+	g_test_add_func("/passim/item/variant", passim_item_variant_func);
+	g_test_add_func("/passim/item/variant-empty", passim_item_variant_empty_func);
+	g_test_add_func("/passim/item/to-string", passim_item_to_string_func);
+	g_test_add_func("/passim/item/to-string-share", passim_item_to_string_share_func);
+	g_test_add_func("/passim/item/load-filename", passim_item_load_filename_func);
+	g_test_add_func("/passim/gnutls/create-private-key", passim_gnutls_create_private_key_func);
+	g_test_add_func("/passim/gnutls/load-privkey", passim_gnutls_load_privkey_func);
+	g_test_add_func("/passim/gnutls/create-certificate", passim_gnutls_create_certificate_func);
+	g_test_add_func("/passim/gnutls/load-crt", passim_gnutls_load_crt_func);
+	g_test_add_func("/passim/gnutls/pubkey", passim_gnutls_pubkey_func);
+	g_test_add_func("/passim/gnutls/datum-to-dn-str", passim_gnutls_datum_to_dn_str_func);
+	g_test_add_func("/passim/client", passim_client_func);
+	g_test_add_func("/passim/version", passim_version_func);
 	return g_test_run();
 }

--- a/src/passim-self-test.test.in
+++ b/src/passim-self-test.test.in
@@ -1,0 +1,3 @@
+[Test]
+Type=session
+Exec=@installed_tests_execdir@/passim-self-test

--- a/src/passim-server.c
+++ b/src/passim-server.c
@@ -34,6 +34,7 @@ typedef struct {
 	guint owner_id;
 	guint poll_item_age_id;
 	guint timed_exit_id;
+	gboolean insecure;
 	guint64 download_saving;
 	PassimStatus status;
 	GHashTable *client_cooldowns; /* element-type utf8:*u64 */
@@ -1301,7 +1302,7 @@ passim_server_sender_check_uid(PassimServer *self, const gchar *sender, GError *
 		return FALSE;
 	}
 	g_variant_get(val, "(u)", &value);
-	if (value != 0) {
+	if (value != 0 && !self->insecure) {
 		g_set_error(error,
 			    G_IO_ERROR,
 			    G_IO_ERROR_PERMISSION_DENIED,
@@ -1705,6 +1706,7 @@ main(int argc, char *argv[])
 {
 	gboolean version = FALSE;
 	gboolean timed_exit = FALSE;
+	gboolean insecure = FALSE;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GOptionContext) context = g_option_context_new(NULL);
 	g_autoptr(GSource) unix_signal_source = g_unix_signal_source_new(SIGINT);
@@ -1715,6 +1717,7 @@ main(int argc, char *argv[])
 	const GOptionEntry options[] = {
 	    {"version", '\0', 0, G_OPTION_ARG_NONE, &version, "Show project version", NULL},
 	    {"timed-exit", '\0', 0, G_OPTION_ARG_NONE, &timed_exit, "Exit after a delay", NULL},
+	    {"insecure", '\0', 0, G_OPTION_ARG_NONE, &insecure, "Skip UID checks", NULL},
 	    {NULL}};
 
 	(void)g_setenv("G_MESSAGES_DEBUG", "all", FALSE);
@@ -1743,6 +1746,7 @@ main(int argc, char *argv[])
 	    g_timeout_add_seconds(60 * 60, passim_server_check_item_age_cb, self);
 	if (timed_exit)
 		self->timed_exit_id = g_timeout_add_seconds(10, passim_server_timed_exit_cb, self);
+	self->insecure = insecure;
 	self->avahi = passim_avahi_new(self->kf);
 	self->client_cooldowns = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 	self->port = passim_config_get_port(self->kf);


### PR DESCRIPTION
Add 24 new C unit tests covering passim-common config helpers, PassimItem properties/flags/serialization, GnuTLS key and certificate generation, and PassimClient defaults. Add a Python integration test using dbusmock to mock Avahi and exercise the real passimd daemon end-to-end via HTTPS requests and D-Bus calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `--insecure` startup option to relax D-Bus UID authorization checks.
  - Added an `installed_tests` Meson option (default on) to install distributed test artefacts, shipped as a new RPM `tests` subpackage.
- **Bug Fixes**
  - Improved handling and validation for edge cases like invalid/zero ports and empty SHA256 input.
- **Testing**
  - Expanded self-test coverage and added an HTTP/HTTPS + D-Bus integration test using mocked system services.
  - Added an optional client/CLI test helper for broader verification.
- **CI**
  - Updated the Fedora CI image to include Python D-Bus and D-Bus mock support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->